### PR TITLE
present fqdn of new server at end of chef run

### DIFF
--- a/lib/chef/knife/bluebox_server_create.rb
+++ b/lib/chef/knife/bluebox_server_create.rb
@@ -173,6 +173,7 @@ class Chef
               bootstrap.config[:use_sudo] = true
               bootstrap.config[:distro] = config[:distro]
               bootstrap.run
+              print "\n#{h.color("Finished bootstrapping #{server.hostname}\n\n", :green)}"
             rescue Errno::ECONNREFUSED
               puts h.color("Connection refused on SSH, retrying - CTRL-C to abort")
               sleep 1


### PR DESCRIPTION
it's convenient to have the fqdn readily available at the end of the chef run
