### PR TITLE
Add 'location list' subcommand & support --location on 'server create'.

### DIFF
--- a/lib/chef/knife/bluebox_location_list.rb
+++ b/lib/chef/knife/bluebox_location_list.rb
@@ -1,0 +1,54 @@
+#
+# Copyright:: Copyright (c) 2013 Blue Box Group
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef/knife'
+
+class Chef
+  class Knife
+    class BlueboxLocationList < Knife
+
+      deps do
+        require 'fog'
+        require 'highline'
+        require 'readline'
+        require 'chef/json_compat'
+      end
+
+      banner "knife bluebox location list"
+
+      def h
+        @highline ||= HighLine.new
+      end
+
+      def run
+        bluebox = Fog::Compute::Bluebox.new(
+          :bluebox_customer_id => Chef::Config[:knife][:bluebox_customer_id],
+          :bluebox_api_key => Chef::Config[:knife][:bluebox_api_key]
+        )
+
+        location_list = [ h.color('ID', :bold), h.color('Description', :bold) ]
+
+        bluebox.locations.each do |location|
+          location_list << location.id.to_s
+          location_list << location.description
+        end
+        puts h.list(location_list, :columns_across, 2)
+
+      end
+    end
+  end
+end

--- a/lib/chef/knife/bluebox_server_create.rb
+++ b/lib/chef/knife/bluebox_server_create.rb
@@ -51,6 +51,12 @@ class Chef
         :description => "The image of the server",
         :default => "a8f05200-7638-47d1-8282-2474ef57c4c3"
 
+      option :location,
+        :short => "-L LOCATION",
+        :long => "--location LOCATION",
+        :description => "The location UUID of the server",
+        :default => "37c2bd9a-3e81-46c9-b6e2-db44a25cc675"
+
       option :username,
         :short => "-U KEY",
         :long => "--username username",
@@ -127,10 +133,12 @@ class Chef
         puts "#{h.color("Deploying a new Blue Box Block...", :green)}\n\n"
 
         image_id = Chef::Config[:knife][:image] || config[:image]
+        location_id = Chef::Config[:knife][:location] || config[:location]
         
         server = bluebox.servers.new(
           :flavor_id => Chef::Config[:knife][:flavor] || config[:flavor],
           :image_id => image_id,
+          :location_id => location_id,
           :hostname => config[:chef_node_name],
           :username => Chef::Config[:knife][:username] || config[:username],
           :password => config[:password],


### PR DESCRIPTION
This command adds the following subcommand:

```
knife bluebox location list
```

A `--location` flag is also added to `knife bluebox server create` and
will default to the Seattle location.
