### PR TITLE
Add BlueboxServerCreate#server for external tooling.

### DIFF
--- a/lib/chef/knife/bluebox_server_create.rb
+++ b/lib/chef/knife/bluebox_server_create.rb
@@ -99,6 +99,8 @@ class Chef
         :description => "Amount of time fog should wait before aborting server deployment.",
         :default => 10 * 60
 
+      attr_reader :server
+
       def h
         @highline ||= HighLine.new
       end
@@ -178,6 +180,7 @@ class Chef
 
           else
             print "\n\n#{h.color("BBG Server startup succesful.  Accessible at #{server.hostname}\n", :green)}"
+            @server = server
 
             # Make sure we should be bootstrapping.
             if config[:disable_bootstrap]


### PR DESCRIPTION
This would provide a mechanism for other Knife plugins to use
BlueboxServerCreate and get a reference to the newly created server.
Useful activities may include obtaining the IP address, hostname,
block_id, etc.

The driving use case is to add Blue Box Blocks support to the
[knife-server](http://fnichol.github.io/knife-server/) gem.
